### PR TITLE
Lock file on .SSD only if source file on .DSD was also locked

### DIFF
--- a/split_mb_dsd.pl
+++ b/split_mb_dsd.pl
@@ -96,7 +96,7 @@ foreach my $dsd (<SRC/*.dsd>)
         next;
       }
       $file='$.' . $file unless $file =~ /^.\./;
-      $game = CleanGameName($game);
+      $game=CleanGameName($game);
       # Lower case cos FOO and foo same on Beeb.  We force comparisons
       # to lc() versions of filenames in the DATA statements 'cos some
       # games have XYZZY in the DATA statement but may be Xyzzy on disk.
@@ -179,7 +179,7 @@ foreach my $dsd (<SRC/*.dsd>)
 
 sub CleanGameName
 {
-  my $game = $_[0];
+  my ($game)=@_;
   # Remove Teletext characters from filename
   $game=~s/[^A-Za-z0-9\s\:]//g;
 

--- a/split_mb_dsd.pl
+++ b/split_mb_dsd.pl
@@ -161,7 +161,11 @@ foreach my $dsd (<SRC/*.dsd>)
                                           $data,
                                           $this_cat->{$_}{load},
                                           $this_cat->{$_}{exec},
-                                          1);  # Always locked
+                                          $this_cat->{$_}{locked});
+                                           # lock file only if source is locked
+
+      print "  On $dsd :$side.$this_cat->{$_}{name} is unlocked\n" 
+        if ($verbose == 2 && !$this_cat->{$_}{locked});
     }
     if ($found)
     {


### PR DESCRIPTION
Again, not really a pull request (not least because I'm not sure I've done it right!), but just letting you know I've updated split_mb_dsd.pl so that a file on a generated .SSD is locked only if the corresponding file on the source .DSD was also locked -- to fix errors like this: https://stardot.org.uk/forums/viewtopic.php?f=57&t=14166&start=60&hilit=Oops#p210789